### PR TITLE
Set the initial dateType "mm-dd" to the first item in the dropdown menu

### DIFF
--- a/fail.marc.onairclock.sdPlugin/app.js
+++ b/fail.marc.onairclock.sdPlugin/app.js
@@ -199,11 +199,11 @@ function updateClock(jsn) {
         }
         //TODO build PI dropdown for date selection
         switch (jsn.payload.settings.dateType) {
-            case "mm-dd":
-                currentElement.dateType = "mm-dd"
-                break;
             case "dd-mm":
                 currentElement.dateType = "dd-mm"
+                break;
+            case "mm-dd":
+                currentElement.dateType = "mm-dd"
                 break;
             case "dd-mm-yy":
                 currentElement.dateType = "dd-mm-yy"
@@ -437,13 +437,13 @@ function displayTime(canvas, jsn) {
             let shortYear = year.toString().substr(-2)
 
             switch(dateType) {
-                case "mm-dd":
-                    context.font = "18px Verdana";
-                    context.fillText(padZero(month) + "-" + padZero(day), clockX, (clockY - 25));
-                    break;
                 case "dd-mm":
                     context.font = "18px Verdana";
                     context.fillText(padZero(day) + "-" + padZero(month), clockX, (clockY - 25));
+                    break;
+                case "mm-dd":
+                    context.font = "18px Verdana";
+                    context.fillText(padZero(month) + "-" + padZero(day), clockX, (clockY - 25));
                     break;
                 case "dd-mm-yy":
                     context.font = "16px Verdana";

--- a/fail.marc.onairclock.sdPlugin/propertyinspector/index.html
+++ b/fail.marc.onairclock.sdPlugin/propertyinspector/index.html
@@ -25,8 +25,8 @@
             <div class="sdpi-item" id="dateTypeSelector">
               <div class="sdpi-item-label">Date Format</div>
               <select class="sdpi-item-value select" id="dateType">
-                 <option value="mm-dd">MM-DD</option>
                  <option value="dd-mm">DD-MM</option>
+                 <option value="mm-dd">MM-DD</option>
                  <option value="dd-mm-yy">DD-MM-YY</option>
                  <option value="mm-dd-yy">MM-DD-YY</option>
                  <option value="yy-mm-dd">YY-MM-DD</option>


### PR DESCRIPTION
After initial installation, the default dateType will be "dd-mm" without any saved json.
However, the first item in the dateType dropdown menu is "mm-dd", so if the user wants to select "mm-dd", the user must select an item at least twice (1. select some other item, 2. select "mm-dd" again).

This PR update dropdown items order and switch cases order in app.js.

It's not related to PR, but I like the design and use it on my Mac and Windows PC. Thank you for developing it.